### PR TITLE
ChatSpaceのデータベース設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,2 @@
 # README
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
-
-Things you may want to cover:
-
-* Ruby version
-
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...

--- a/README.md
+++ b/README.md
@@ -13,3 +13,6 @@
 - has_many :groups, through: :groups_users
 
 ### groupsテーブル
+|Column   |Type  |Options                  |
+|---------|------|-------------------------|
+|groupname|string|null: false, unique: true|

--- a/README.md
+++ b/README.md
@@ -38,3 +38,4 @@
 |image        |string |                                           |
 |group_id     |integer|null: false, foreign_key: true             |
 |group_user_id|integer|null: false, foreign_key: true, index: true|
+#### Association

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 ## ChatSpace データベース設計
 
+### groupsテーブル
+|Column   |Type  |Options                  |
+|---------|------|-------------------------|
+|groupname|string|null: false, unique: true|
+#### Association
+- has_many :groups_users
+- has_many :users, through: :groups_users
+- has_many :messages
+
 ### usersテーブル
 |Column  |Type  |Options                               |
 |--------|------|--------------------------------------|
@@ -11,15 +20,6 @@
 #### Association
 - has_many :groups_users
 - has_many :groups, through: :groups_users
-
-### groupsテーブル
-|Column   |Type  |Options                  |
-|---------|------|-------------------------|
-|groupname|string|null: false, unique: true|
-#### Association
-- has_many :groups_users
-- has_many :users, through: :groups_users
-- has_many :messages
 
 ### groups_usersテーブル
 |Column  |Type   |Options                                    |

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ### usersテーブル
 |Column  |Type  |Options                               |
 |--------|------|--------------------------------------|
-|username|string|null: false, unique: true, index: true|
+|name    |string|null: false, unique: true, index: true|
 |email   |string|null: false, unique: true, index: true|
 |password|string|null: false                           |
 #### Association

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@
 - has_many :messages
 
 ### groups_usersテーブル
-|Column  |Type      |Options                                    |
-|--------|----------|-------------------------------------------|
-|group_id|references|null: false, foreign_key: true             |
-|user_id |references|null: false, foreign_key: true, index: true|
+|Column|Type      |Options                       |
+|------|----------|------------------------------|
+|group |references|null: false, foreign_key: true|
+|user  |references|null: false, foreign_key: true|
 #### Association
 - belongs_to :group
 - belongs_to :user

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 #### Association
 - has_many :groups_users
 - has_many :groups, through: :groups_users
+- has_many :messages
 
 ### groups_usersテーブル
 |Column  |Type      |Options                                    |

--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@
 |username|string|null: false, unique: true, index: true|
 |email   |string|null: false, unique: true, index: true|
 |password|string|null: false                           |
+#### Association

--- a/README.md
+++ b/README.md
@@ -22,3 +22,7 @@
 - has_many :messages
 
 ### groups_usersテーブル
+|Column  |Type   |Options                                    |
+|--------|-------|-------------------------------------------|
+|group_id|integer|null: false, foreign_key: true             |
+|user_id |integer|null: false, foreign_key: true, index: true|

--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@
 |group_user_id|references|null: false, foreign_key: true, index: true|
 #### Association
 - belongs_to :group
-- belongs_to :group_user
+- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -32,3 +32,9 @@
 - has_many   :messages
 
 ### messagesテーブル
+|Column       |Type   |Options                                    |
+|-------------|-------|-------------------------------------------|
+|body         |text   |null: false                                |
+|image        |string |                                           |
+|group_id     |integer|null: false, foreign_key: true             |
+|group_user_id|integer|null: false, foreign_key: true, index: true|

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 ## ChatSpace データベース設計
 
 ### groupsテーブル
-|Column   |Type  |Options                  |
-|---------|------|-------------------------|
-|groupname|string|null: false, unique: true|
+|Column   |Type|Options                  |
+|---------|----|-------------------------|
+|groupname|text|null: false, unique: true|
 #### Association
 - has_many :groups_users
 - has_many :users, through: :groups_users

--- a/README.md
+++ b/README.md
@@ -16,3 +16,5 @@
 |Column   |Type  |Options                  |
 |---------|------|-------------------------|
 |groupname|string|null: false, unique: true|
+#### Association
+

--- a/README.md
+++ b/README.md
@@ -11,3 +11,5 @@
 #### Association
 - has_many :groups_users
 - has_many :groups, through: :groups_users
+
+### groupsテーブル

--- a/README.md
+++ b/README.md
@@ -2,3 +2,4 @@
 
 ## ChatSpace データベース設計
 
+### usersテーブル

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@
 - belongs_to :user
 
 ### messagesテーブル
-|Column       |Type      |Options                                    |
-|-------------|----------|-------------------------------------------|
-|body         |text      |                                           |
-|image        |string    |                                           |
-|group_id     |references|null: false, foreign_key: true             |
-|group_user_id|references|null: false, foreign_key: true, index: true|
+|Column|Type      |Options                       |
+|------|----------|------------------------------|
+|body  |text      |                              |
+|image |string    |                              |
+|group |references|null: false, foreign_key: true|
+|user  |references|null: false, foreign_key: true|
 #### Association
 - belongs_to :group
 - belongs_to :user

--- a/README.md
+++ b/README.md
@@ -22,22 +22,22 @@
 - has_many :groups, through: :groups_users
 
 ### groups_usersテーブル
-|Column  |Type   |Options                                    |
-|--------|-------|-------------------------------------------|
-|group_id|integer|null: false, foreign_key: true             |
-|user_id |integer|null: false, foreign_key: true, index: true|
+|Column  |Type      |Options                                    |
+|--------|----------|-------------------------------------------|
+|group_id|references|null: false, foreign_key: true             |
+|user_id |references|null: false, foreign_key: true, index: true|
 #### Association
 - belongs_to :group
 - belongs_to :user
 - has_many   :messages
 
 ### messagesテーブル
-|Column       |Type   |Options                                    |
-|-------------|-------|-------------------------------------------|
-|body         |text   |null: false                                |
-|image        |string |                                           |
-|group_id     |integer|null: false, foreign_key: true             |
-|group_user_id|integer|null: false, foreign_key: true, index: true|
+|Column       |Type      |Options                                    |
+|-------------|----------|-------------------------------------------|
+|body         |text      |null: false                                |
+|image        |string    |                                           |
+|group_id     |references|null: false, foreign_key: true             |
+|group_user_id|references|null: false, foreign_key: true, index: true|
 #### Association
 - belongs_to :group
 - belongs_to :group_user

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # README
 
+## ChatSpace データベース設計
+

--- a/README.md
+++ b/README.md
@@ -3,3 +3,8 @@
 ## ChatSpace データベース設計
 
 ### usersテーブル
+|Column  |Type  |Options                               |
+|--------|------|--------------------------------------|
+|username|string|null: false, unique: true, index: true|
+|email   |string|null: false, unique: true, index: true|
+|password|string|null: false                           |

--- a/README.md
+++ b/README.md
@@ -27,3 +27,6 @@
 |group_id|integer|null: false, foreign_key: true             |
 |user_id |integer|null: false, foreign_key: true, index: true|
 #### Association
+- belongs_to :group
+- belongs_to :user
+- has_many   :messages

--- a/README.md
+++ b/README.md
@@ -20,3 +20,5 @@
 - has_many :groups_users
 - has_many :users, through: :groups_users
 - has_many :messages
+
+### groups_usersテーブル

--- a/README.md
+++ b/README.md
@@ -17,4 +17,6 @@
 |---------|------|-------------------------|
 |groupname|string|null: false, unique: true|
 #### Association
-
+- has_many :groups_users
+- has_many :users, through: :groups_users
+- has_many :messages

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 ### messagesテーブル
 |Column       |Type      |Options                                    |
 |-------------|----------|-------------------------------------------|
-|body         |text      |null: false                                |
+|body         |text      |                                           |
 |image        |string    |                                           |
 |group_id     |references|null: false, foreign_key: true             |
 |group_user_id|references|null: false, foreign_key: true, index: true|

--- a/README.md
+++ b/README.md
@@ -26,3 +26,4 @@
 |--------|-------|-------------------------------------------|
 |group_id|integer|null: false, foreign_key: true             |
 |user_id |integer|null: false, foreign_key: true, index: true|
+#### Association

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 ## ChatSpace データベース設計
 
 ### groupsテーブル
-|Column   |Type|Options                  |
-|---------|----|-------------------------|
-|groupname|text|null: false, unique: true|
+|Column|Type  |Options                  |
+|------|------|-------------------------|
+|name  |string|null: false, unique: true|
 #### Association
 - has_many :groups_users
 - has_many :users, through: :groups_users

--- a/README.md
+++ b/README.md
@@ -30,3 +30,5 @@
 - belongs_to :group
 - belongs_to :user
 - has_many   :messages
+
+### messagesテーブル

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@
 #### Association
 - belongs_to :group
 - belongs_to :user
-- has_many   :messages
 
 ### messagesテーブル
 |Column       |Type      |Options                                    |

--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@
 |email   |string|null: false, unique: true, index: true|
 |password|string|null: false                           |
 #### Association
+- has_many :groups_users
+- has_many :groups, through: :groups_users

--- a/README.md
+++ b/README.md
@@ -39,3 +39,5 @@
 |group_id     |integer|null: false, foreign_key: true             |
 |group_user_id|integer|null: false, foreign_key: true, index: true|
 #### Association
+- belongs_to :group
+- belongs_to :group_user


### PR DESCRIPTION
 # What
ChatSpaceのデータベースの設計書をREADME.mdファイルに記載する。当サービスの機能により今回は４つのエンティティに分類することができた。各エンティティにおいて記載する項目は以下の５点である。
- テーブル名
- カラム名
- カラムの型
- カラムのオプション
- アソシエーション

また、４つのテーブルの内の一つである*groups_users*は**中間テーブル**である。

# Why
データベース設計をサービス実装の前段階でやっておくことにより、データやデータ同士の関係性を明確にしておくだけでなく、後に複雑な機能を導入することになっても効率的かつ簡易的にデータの操作や管理を行うことが可能になる。

# How
*groups*テーブルと*users*テーブルが**多対多**の関係になるので、中間テーブルとして*groups_users*テーブルを設定した。また、当サービスはグループ内でのチャットを前提としているため、そのグループに所属していないメンバーはチャットに参加できないように、UserモデルとMessageモデルではなく、中間テーブルである**GroupUser**モデルとMessageモデルをアソシエーションとして紐付けた。更に、メールアドレスだけではなく、グループ名とユーザー名にも既に使われているものを登録できないようにするために一意性制約を設けた。 

# Others(疑問点)
- グループ名に一意性制約を設けたが、インデックスを貼るべきかどうか。理論上だとグループ数はユーザー数よりも少なくなるし、あまり貼りすぎても重くなる原因になるため、今回は省略した。
- ユーザー名にも同様に一意性制約を設けたが、このフォーム欄にフルネームを記入するように促した場合、同名の人が後からフルネームで登録できなくなるという問題が発生する。逆に一意性制約を解除してしまうと、今度は他のメールアドレスでサブアカウントを発行するときに、同じ人が同じ名前で複数のアカウントを所有することができるようになり、別の問題が発生する恐れがある。
今回は~~大人気SNSアプリ*Twitter*のように~~、前者のままサブアカウントで同じ名前を登録できないようにして、これはサイト上にも表示される名前であるため、別で固有のアカウント名を記入してもらう機能を追加したときにそちらでフルネームで登録できるようにする。
- messagesテーブルの外部キーである*group_user_id*にインデックスを貼るべきかどうか。グループ数と同じくユーザーの数よりも実質少なくなる筈だが、ある一つのグループに当サービスに登録している全ユーザーが追加される可能性もあるので、貼ることにした。
- カリキュラムだと外部キーの型が*integer*になっているみたいだが、*references*型でも良いのか。
- messagesテーブルの外部キーの*group_user_id*と同テーブルのアソシエーションの*group_user*に複数形の“s”を付けるべきか否か。userの方はそのまま単数形で良いとしても、“groups_user”と表記すべきか迷ったが、今回はgroupの方も単数形で表すことにした。