### PR TITLE
ChatSpaceのユーザーインクリメンタルサーチの実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -6,7 +6,7 @@ $(function () {
                 ${message.name}
               </p>
               <p class="MessageInfo__TopBox--Date">
-                ${message.time}
+                ${message.date}
               </p>
             </div>
             <p class="MessageInfo--Text">
@@ -42,13 +42,12 @@ $(function () {
     .done(function (data) {
       var html = buildHTML(data);
       $('.MainChat__MessageList').append(html);
-      $('.MainChat__MessageList').animate({ scrollTop: $('.MainChat__MessageList')[0].scrollHeight});
+      $('.MainChat__MessageList').animate({ scrollTop: $('.MainChat__MessageList')[0].scrollHeight }, 'fast');
       $('form')[0].reset();
-      $('.NewMessage--SendBtn').prop('disabled', false);
     })
     .fail(function () {
       alert("メッセージを入力してください。");
-      $('.NewMessage--SendBtn').prop('disabled', false);
     });
+    return false;
   });
 });

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -5,14 +5,14 @@ $(function () {
                   <p class="chat-group-user__name">${user.name}</p>
                   <a class="chat-group-user__btn chat-group-user__btn--add" data-user-id="${user.id}" data-user-name="${user.name}">追加</a>
                 </div>`;
-    return html;
+    $('#user-search-result').append(html);
   };
 
   function appendErrMsg(msg) {
     var html = `<div class="chat-group-user">
                   <p class="chat-group-user__name">${msg}</p>
                 </div>`;
-    return html;
+    $('#user-search-result').append(html);
   };
 
   $('#user_search').on('keyup', function () {
@@ -27,12 +27,10 @@ $(function () {
       $('#user-search-result').empty();
       if (users.length !== 0) {
         users.forEach(function (user) {
-          var html = appendUser(user);
-          console.log(html);
+          appendUser(user);
         });
       } else if (input !== "") {
-        var html = appendErrMsg("一致するユーザーが見つかりません");
-        console.log(html);
+        appendErrMsg("一致するユーザーが見つかりません");
       };
     })
     .fail(function () {

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -2,5 +2,6 @@ $(function () {
 
   $('#user-search-field').on('keyup', function () {
     var input = $(this).val();
+    console.log(input);
   });
 });

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -1,6 +1,6 @@
 $(function () {
 
   $('#user-search-field').on('keyup', function () {
-
+    var input = $(this).val();
   });
 });

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -33,7 +33,6 @@ $(function () {
       dataType: 'json'
     })
     .done(function (users) {
-      console.log(users);
       $('#user-search-result').empty();
       if (users.length !== 0) {
         users.forEach(function (user) {

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -57,7 +57,7 @@ $(function () {
   });
 
   $('#chat-group-users').on('click', '.chat-group-user__btn--remove', function () {
-
+    console.log("イベント発火成功");
   });
 
 });

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -5,12 +5,14 @@ $(function () {
                   <p class="chat-group-user__name">${user.name}</p>
                   <a class="chat-group-user__btn chat-group-user__btn--add" data-user-id="${user.id}" data-user-name="${user.name}">追加</a>
                 </div>`;
+    return html;
   };
 
   function appendErrMsg(msg) {
     var html = `<div class="chat-group-user">
                   <p class="chat-group-user__name">${msg}</p>
                 </div>`;
+    return html;
   };
 
   $('#user_search').on('keyup', function () {

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -9,7 +9,7 @@ $(function () {
       dataType: 'json'
     })
     .done(function (users) {
-      console.log(users);
+      $('#user-search-result').empty();
     })
     .fail(function () {
       console.log("失敗です。");

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -1,5 +1,12 @@
 $(function () {
 
+  function appendUser(user) {
+    var html = `<div class="chat-group-user">
+                  <p class="chat-group-user__name">${user.name}</p>
+                  <a class="chat-group-user__btn chat-group-user__btn--add" data-user-id="${user.id}" data-user-name="${user.name}">追加</a>
+                </div>`;
+  };
+
   $('#user_search').on('keyup', function () {
     var input = $(this).val();
     $.ajax({

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -1,7 +1,7 @@
 $(function () {
 
   function addUser(user) {
-    var html = `<div class="chat-group-user">
+    var html = `<div class="chat-group-user clearfix">
                   <p class="chat-group-user__name">${user.name}</p>
                   <a class="chat-group-user__btn chat-group-user__btn--add" data-user-id="${user.id}" data-user-name="${user.name}">追加</a>
                 </div>`;
@@ -9,14 +9,14 @@ $(function () {
   };
 
   function addNoUser(msg) {
-    var html = `<div class="chat-group-user">
+    var html = `<div class="chat-group-user clearfix">
                   <p class="chat-group-user__name">${msg}</p>
                 </div>`;
     $('#user-search-result').append(html);
   };
 
   function addChatMember(user_id, user_name) {
-    var html = `<div class="chat-group-user">
+    var html = `<div class="chat-group-user clearfix">
                   <input name="group[user_ids][]" type="hidden" value="${user_id}">
                   <p class="chat-group-user__name">${user_name}</p>
                   <a class="chat-group-user__btn chat-group-user__btn--remove">削除</a>

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -1,6 +1,6 @@
 $(function () {
 
-  function appendUser(user) {
+  function addUser(user) {
     var html = `<div class="chat-group-user">
                   <p class="chat-group-user__name">${user.name}</p>
                   <a class="chat-group-user__btn chat-group-user__btn--add" data-user-id="${user.id}" data-user-name="${user.name}">追加</a>
@@ -8,7 +8,7 @@ $(function () {
     $('#user-search-result').append(html);
   };
 
-  function appendErrMsg(msg) {
+  function addNoUser(msg) {
     var html = `<div class="chat-group-user">
                   <p class="chat-group-user__name">${msg}</p>
                 </div>`;
@@ -27,10 +27,10 @@ $(function () {
       $('#user-search-result').empty();
       if (users.length !== 0) {
         users.forEach(function (user) {
-          appendUser(user);
+          addUser(user);
         });
       } else if (input !== "") {
-        appendErrMsg("一致するユーザーが見つかりません");
+        addNoUser("一致するユーザーが見つかりません");
       };
     })
     .fail(function () {

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -34,7 +34,7 @@ $(function () {
       };
     })
     .fail(function () {
-      console.log("失敗です。");
+      alert("ユーザー検索に失敗しました");
     });
   });
 });

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -7,6 +7,12 @@ $(function () {
                 </div>`;
   };
 
+  function appendErrMsg(msg) {
+    var html = `<div class="chat-group-user">
+                  <p class="chat-group-user__name">${msg}</p>
+                </div>`;
+  };
+
   $('#user_search').on('keyup', function () {
     var input = $(this).val();
     $.ajax({

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -2,5 +2,11 @@ $(function () {
 
   $('#user_search').on('keyup', function () {
     var input = $(this).val();
+    $.ajax({
+      url: '/users',
+      type: 'GET',
+      data: { keyword: input },
+      dataType: 'json'
+    })
   });
 });

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -11,7 +11,9 @@ $(function () {
     .done(function (users) {
       $('#user-search-result').empty();
       if (users.length !== 0) {
+        users.forEach(function (user) {
 
+        });
       } else {
 
       };

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -30,7 +30,7 @@ $(function () {
           var html = appendUser(user);
           console.log(html);
         });
-      } else {
+      } else if (input !== "") {
         var html = appendErrMsg("一致するユーザーが見つかりません");
         console.log(html);
       };

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -38,5 +38,9 @@ $(function () {
     .fail(function () {
       alert("ユーザー検索に失敗しました");
     });
+
+    $('#user-search-result').on('click', '.chat-group-user__btn--add', function () {
+      // console.log()でイベント発火の有無を確認しましょう
+    });
   });
 });

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -29,8 +29,10 @@ $(function () {
         users.forEach(function (user) {
           addUser(user);
         });
-      } else if (input !== "") {
+      } else if (input.length !== 0) {
         addNoUser("一致するユーザーが見つかりません");
+      } else {
+        return false;
       };
     })
     .fail(function () {

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -9,7 +9,7 @@ $(function () {
       dataType: 'json'
     })
     .done(function (users) {
-      console.log("成功です。");
+      console.log(users);
     })
     .fail(function () {
       console.log("失敗です。");

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -1,0 +1,6 @@
+$(function () {
+
+  $('#user-search-field').on('keyup', function () {
+
+  });
+});

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -27,10 +27,12 @@ $(function () {
       $('#user-search-result').empty();
       if (users.length !== 0) {
         users.forEach(function (user) {
-          appendUser(user);
+          var html = appendUser(user);
+          console.log(html);
         });
       } else {
-        appendErrMsg(user);
+        var html = appendErrMsg("一致するユーザーが見つかりません");
+        console.log(html);
       };
     })
     .fail(function () {

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -49,14 +49,14 @@ $(function () {
     });
   });
 
-  $('#user-search-result').on('click', '.chat-group-user__btn--add', function () {
+  $(document).on('click', '.chat-group-user__btn--add', function () {
     var user_id = $(this).attr('data-user-id');
     var user_name = $(this).attr('data-user-name');
     $(this).parent().remove();
     addChatMember(user_id, user_name);
   });
 
-  $('#chat-group-users').on('click', '.chat-group-user__btn--remove', function () {
+  $(document).on('click', '.chat-group-user__btn--remove', function () {
     $(this).parent().remove();
   });
 

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -42,6 +42,7 @@ $(function () {
     $('#user-search-result').on('click', '.chat-group-user__btn--add', function () {
       var user_id = $(this).attr('data-user-id');
       var user_name = $(this).attr('data-user-name');
+      $(this).parent().remove();
     });
   });
 });

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -27,10 +27,10 @@ $(function () {
       $('#user-search-result').empty();
       if (users.length !== 0) {
         users.forEach(function (user) {
-
+          appendUser(user);
         });
       } else {
-
+        appendErrMsg(user);
       };
     })
     .fail(function () {

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -15,6 +15,15 @@ $(function () {
     $('#user-search-result').append(html);
   };
 
+  function addChatMember(user_id, user_name) {
+    var html = `<div class="chat-group-user">
+                  <input name="group[user_ids][]" type="hidden" value="${user_id}">
+                  <p class="chat-group-user__name">${user_name}</p>
+                  <a class="chat-group-user__btn chat-group-user__btn--remove">削除</a>
+                </div>`;
+    $('#chat-group-users').append(html);
+  };
+
   $('#user_search').on('keyup', function () {
     var input = $(this).val();
     $.ajax({
@@ -38,11 +47,13 @@ $(function () {
     .fail(function () {
       alert("ユーザー検索に失敗しました");
     });
-
-    $('#user-search-result').on('click', '.chat-group-user__btn--add', function () {
-      var user_id = $(this).attr('data-user-id');
-      var user_name = $(this).attr('data-user-name');
-      $(this).parent().remove();
-    });
   });
+
+  $('#user-search-result').on('click', '.chat-group-user__btn--add', function () {
+    var user_id = $(this).attr('data-user-id');
+    var user_name = $(this).attr('data-user-name');
+    $(this).parent().remove();
+    addChatMember(user_id, user_name);
+  });
+
 });

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -33,6 +33,7 @@ $(function () {
       dataType: 'json'
     })
     .done(function (users) {
+      console.log(users);
       $('#user-search-result').empty();
       if (users.length !== 0) {
         users.forEach(function (user) {

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -56,4 +56,8 @@ $(function () {
     addChatMember(user_id, user_name);
   });
 
+  $('#chat-group-users').on('click', '.chat-group-user__btn--remove', function () {
+
+  });
+
 });

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -57,7 +57,7 @@ $(function () {
   });
 
   $('#chat-group-users').on('click', '.chat-group-user__btn--remove', function () {
-    console.log("イベント発火成功");
+    $(this).parent().remove();
   });
 
 });

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -40,7 +40,8 @@ $(function () {
     });
 
     $('#user-search-result').on('click', '.chat-group-user__btn--add', function () {
-      console.log("イベント発火成功");
+      var user_id = $(this).attr('data-user-id');
+      var user_name = $(this).attr('data-user-name');
     });
   });
 });

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -1,7 +1,6 @@
 $(function () {
 
-  $('#user-search-field').on('keyup', function () {
+  $('#user_search').on('keyup', function () {
     var input = $(this).val();
-    console.log(input);
   });
 });

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -40,7 +40,7 @@ $(function () {
     });
 
     $('#user-search-result').on('click', '.chat-group-user__btn--add', function () {
-      // console.log()でイベント発火の有無を確認しましょう
+      console.log("イベント発火成功");
     });
   });
 });

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -8,5 +8,11 @@ $(function () {
       data: { keyword: input },
       dataType: 'json'
     })
+    .done(function (users) {
+      console.log("成功です。");
+    })
+    .fail(function () {
+      console.log("失敗です。");
+    });
   });
 });

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -10,6 +10,11 @@ $(function () {
     })
     .done(function (users) {
       $('#user-search-result').empty();
+      if (users.length !== 0) {
+
+      } else {
+
+      };
     })
     .fail(function () {
       console.log("失敗です。");

--- a/app/assets/stylesheets/modules/_group.scss
+++ b/app/assets/stylesheets/modules/_group.scss
@@ -46,7 +46,6 @@ li {
     text-align: right;
   }
   &__input {
-    float: left;
     width: 100%;
     line-height: 30px;
     padding: 10px 15px;
@@ -95,7 +94,7 @@ li {
     float: left;
   }
   &__btn {
-    display: inline-block;
+    float: right;
     cursor: pointer;
     &--add {
       color: #38aef0;

--- a/app/assets/stylesheets/modules/_group.scss
+++ b/app/assets/stylesheets/modules/_group.scss
@@ -58,6 +58,7 @@ li {
     color: #fff;
     background-color: #38aef0;
     border: 0;
+    cursor: pointer;
   }
   &__field {
     margin-top: 30px;
@@ -94,7 +95,6 @@ li {
     float: left;
   }
   &__btn {
-    float: right;
     display: inline-block;
     cursor: pointer;
     &--add {

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -12,7 +12,6 @@ class GroupsController < ApplicationController
 
   def create
     @group = Group.new(group_params)
-    binding.pry
     if @group.save
       redirect_to root_path, notice: "グループを作成しました。"
     else

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -12,6 +12,7 @@ class GroupsController < ApplicationController
 
   def create
     @group = Group.new(group_params)
+    binding.pry
     if @group.save
       redirect_to root_path, notice: "グループを作成しました。"
     else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,8 @@
 class UsersController < ApplicationController
 
+  def index
+  end
+
   def edit
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,6 @@ class UsersController < ApplicationController
   def index
     return nil if (params[:keyword] == "")
     @users = User.search(params[:keyword], current_user)
-    binding.pry
   end
 
   def edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,7 @@
 class UsersController < ApplicationController
 
   def index
+    binding.pry
   end
 
   def edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,8 @@
 class UsersController < ApplicationController
 
   def index
-    binding.pry
+    return nil if (params[:keyword] == "")
+    @users = User.where('name LIKE ?', "%#{params[:keyword]}%").where.not(id: current_user.id).limit(10)
   end
 
   def edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,7 @@ class UsersController < ApplicationController
   def index
     return nil if (params[:keyword] == "")
     @users = User.where('name LIKE ?', "%#{params[:keyword]}%").where.not(id: current_user.id).limit(10)
+    binding.pry
   end
 
   def edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@ class UsersController < ApplicationController
 
   def index
     return nil if (params[:keyword] == "")
-    @users = User.where('name LIKE ?', "%#{params[:keyword]}%").where.not(id: current_user.id).limit(10)
+    @users = User.search(params[:keyword], current_user)
     binding.pry
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,8 @@ class User < ApplicationRecord
   has_many :messages
 
   validates :name, presence: true, uniqueness: true
+
+  def self.search(input, user)
+    User.where('name LIKE ?', "%#{input}%").where.not(id: user.id).limit(10)
+  end
 end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -1,24 +1,32 @@
 = form_for group do |f|
+
   - if group.errors.any?
     .chat-group-form__errors
       %h2= "#{group.errors.full_messages.count}件のエラーが発生しました。"
       %ul
         - group.errors.full_messages.each do |message|
           %li= message
+
   .chat-group-form__field
     .chat-group-form__field--left
       = f.label :title, class: 'chat-group-form__label'
     .chat-group-form__field--right
       = f.text_field :title, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
-  .chat-group-form__field.clearfix
-    / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+
+  .chat-group-form__field
+    .chat-group-form__field--left
+      %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
+    .chat-group-form__field--right
+      .chat-group-form__search.clearfix
+        %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
+      #user-search-result
+
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
-      %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
+      %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
-      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-      = f.collection_check_boxes :user_ids, User.all, :id, :name
-      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+      #chat-group-users.js-add-user
+
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -7,26 +7,29 @@
         - group.errors.full_messages.each do |message|
           %li= message
 
-  .chat-group-form__field
+  .chat-group-form__field.clearfix
     .chat-group-form__field--left
       = f.label :title, class: 'chat-group-form__label'
     .chat-group-form__field--right
       = f.text_field :title, class: 'chat-group-form__input', placeholder: 'グループ名を入力してください'
 
-  .chat-group-form__field
+  .chat-group-form__field.clearfix
     .chat-group-form__field--left
-      %label.chat-group-form__label{:for => "user_search"} チャットメンバーを追加
+      %label.chat-group-form__label{for: "user_search"} チャットメンバーを追加
     .chat-group-form__field--right
-      %input#user_search.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}
+      %input#user_search.chat-group-form__input{placeholder: "追加したいユーザー名を入力してください", type: "text"}
       #user-search-result
 
-  .chat-group-form__field
+  .chat-group-form__field.clearfix
     .chat-group-form__field--left
       .chat-group-form__label チャットメンバー
     .chat-group-form__field--right
       #chat-group-users
+        .chat-group-user.clearfix
+          %input{name: "group[user_ids][]", type: "hidden", value: current_user.id}
+          %p.chat-group-user__name= current_user.name
 
-  .chat-group-form__field
+  .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right
       = f.submit class: 'chat-group-form__action-btn'

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -11,23 +11,22 @@
     .chat-group-form__field--left
       = f.label :title, class: 'chat-group-form__label'
     .chat-group-form__field--right
-      = f.text_field :title, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
+      = f.text_field :title, class: 'chat-group-form__input', placeholder: 'グループ名を入力してください'
 
   .chat-group-form__field
     .chat-group-form__field--left
-      %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
+      %label.chat-group-form__label{:for => "user_search"} チャットメンバーを追加
     .chat-group-form__field--right
-      .chat-group-form__search.clearfix
-        %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
+      %input#user_search.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}
       #user-search-result
 
-  .chat-group-form__field.clearfix
+  .chat-group-form__field
     .chat-group-form__field--left
       %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
       #chat-group-users.js-add-user
 
-  .chat-group-form__field.clearfix
+  .chat-group-form__field
     .chat-group-form__field--left
     .chat-group-form__field--right
       = f.submit class: 'chat-group-form__action-btn'

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -22,9 +22,9 @@
 
   .chat-group-form__field
     .chat-group-form__field--left
-      %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
+      .chat-group-form__label チャットメンバー
     .chat-group-form__field--right
-      #chat-group-users.js-add-user
+      #chat-group-users
 
   .chat-group-form__field
     .chat-group-form__field--left

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -25,9 +25,12 @@
       .chat-group-form__label チャットメンバー
     .chat-group-form__field--right
       #chat-group-users
-        .chat-group-user.clearfix
-          %input{name: "group[user_ids][]", type: "hidden", value: current_user.id}
-          %p.chat-group-user__name= current_user.name
+        - group.users.each do |user|
+          .chat-group-user.clearfix
+            %input{name: "group[user_ids][]", type: "hidden", value: user.id}
+            %p.chat-group-user__name= user.name
+            - if(user.id != current_user.id)
+              %a.chat-group-user__btn.chat-group-user__btn--remove 削除
 
   .chat-group-form__field.clearfix
     .chat-group-form__field--left

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,4 @@
 json.name  @message.user.name
-json.time  @message.created_at.strftime("%Y/%m/%d(%a) %T")
+json.date  @message.created_at.strftime("%Y/%m/%d(%a) %T")
 json.text  @message.body
 json.image @message.image.url

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,3 +1,4 @@
-json.array! @users do
-
+json.array! @users do |user|
+  json.id   user.id
+  json.name user.name
 end

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,3 @@
+json.array! @users do
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root "groups#index"
-  resources :users, only: [:edit, :update]
+  resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:index, :new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   root "groups#index"
   resources :users, only: [:index, :edit, :update]
-  resources :groups, only: [:index, :new, :create, :edit, :update] do
+  resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
   end
 end


### PR DESCRIPTION
# What
グループ新規作成・編集更新の各画面において、ユーザーをインクリメンタルサーチできるようにする。その後、チャットメンバーの追加・削除を自由に操作できる機能も実装する。

# Why
現状のChatSpaceだとチャットメンバーの追加・削除をチェックボックスで切替える仕組みになっているが、ユーザーの数が増えるとその操作対象を探す作業がとても大変になる。そこで、今回のテーマであるインクリメンタルサーチ機能を実装することによって、必要なユーザーのみを文字を打ちながらリアルタイムで検索して抽出操作することが可能になる。