### PR TITLE
ChatSpaceの自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -83,5 +83,7 @@ $(function () {
     });
   };
 
-  setInterval(reloadMessages, 7000);
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  };
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -16,12 +16,14 @@ $(function () {
 
   function buildHTML(message) {
     if (message.image) {
-      return `<div class="MessageInfo">
+      // data-message-idが反映されるようにしている
+      return `<div class="MessageInfo" data-message-id=${message.id}>
                 ${buildTopBox_and_Text(message)}
                 <img src=${message.image} class="MessageInfo--Img">
               </div>`;
     } else {
-      return `<div class="MessageInfo">
+      // 同様にdata-message-idが反映されるようにしている
+      return `<div class="MessageInfo" data-message-id=${message.id}>
                 ${buildTopBox_and_Text(message)}
               </div>`;
     };

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -72,6 +72,8 @@ $(function () {
       messages.forEach(function (message) {
         insertHTML += buildHTML(message);
       });
+      // メッセージが入ったHTMLに入れ物ごと追加
+      $('.MainChat__MessageList').append(insertHTML);
     })
     .fail(function () {
       alert("error");

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -66,15 +66,17 @@ $(function () {
       dataType: 'json'
     })
     .done(function (messages) {
-      // 追加するHTMLの入れ物を作る
-      var insertHTML = "";
-      // 配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物insertHTMLに足し合わせる
-      messages.forEach(function (message) {
-        insertHTML += buildHTML(message);
-      });
-      // メッセージが入ったHTMLに入れ物ごと追加
-      $('.MainChat__MessageList').append(insertHTML);
-      $('.MainChat__MessageList').animate({ scrollTop: $('.MainChat__MessageList')[0].scrollHeight }, 'fast');
+      if (messages.length !== 0) {
+        // 追加するHTMLの入れ物を作る
+        var insertHTML = "";
+        // 配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物insertHTMLに足し合わせる
+        messages.forEach(function (message) {
+          insertHTML += buildHTML(message);
+        });
+        // メッセージが入ったHTMLに入れ物ごと追加
+        $('.MainChat__MessageList').append(insertHTML);
+        $('.MainChat__MessageList').animate({ scrollTop: $('.MainChat__MessageList')[0].scrollHeight }, 'fast');
+      };
     })
     .fail(function () {
       alert("error");

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -55,7 +55,7 @@ $(function () {
 
   var reloadMessages = function () {
     // カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
-    var last_message_id = $('.message:last').data("message-id");
+    var last_message_id = $('.MessageInfo:last').data("message-id");
     $.ajax({
       // ルーティングで設定した通りのURLを指定
       url: 'api/messages',

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,8 +1,5 @@
 $(function () {
 
-  var last_message_id = $('.MessageInfo:last').data('message-id');
-  console.log(last_message_id);
-
   function buildTopBox_and_Text(message) {
     return `<div class="MessageInfo__TopBox">
               <p class="MessageInfo__TopBox--Name">
@@ -53,4 +50,25 @@ $(function () {
     });
     return false;
   });
+
+  var reloadMessages = function () {
+    //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
+    var last_message_id = $('.message:last').data("message-id");
+    $.ajax({
+      //ルーティングで設定した通り/groups/id番号/api/messagesとなるように文字列を書く
+      url: 'api/messages',
+      //ルーティングで設定した通りhttpメソッドをGETに指定
+      type: 'GET',
+      //dataオプションでリクエストに値を含める
+      data: { id: last_message_id },
+      dataType: 'json'
+    })
+    .done(function (messages) {
+      console.log("success");
+    })
+    .fail(function () {
+      alert("error");
+    });
+  };
+
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -66,7 +66,8 @@ $(function () {
       dataType: 'json'
     })
     .done(function (messages) {
-      console.log("success");
+      // 追加するHTMLの入れ物を作る
+      var insertHTML = "";
     })
     .fail(function () {
       alert("error");

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -68,6 +68,10 @@ $(function () {
     .done(function (messages) {
       // 追加するHTMLの入れ物を作る
       var insertHTML = "";
+      // 配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物insertHTMLに足し合わせる
+      messages.forEach(function (message) {
+        insertHTML += buildHTML(message);
+      });
     })
     .fail(function () {
       alert("error");

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -80,4 +80,5 @@ $(function () {
     });
   };
 
+  setInterval(reloadMessages, 7000);
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -54,14 +54,14 @@ $(function () {
   });
 
   var reloadMessages = function () {
-    //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
+    // カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
     var last_message_id = $('.message:last').data("message-id");
     $.ajax({
-      //ルーティングで設定した通り/groups/id番号/api/messagesとなるように文字列を書く
+      // ルーティングで設定した通りのURLを指定
       url: 'api/messages',
-      //ルーティングで設定した通りhttpメソッドをGETに指定
+      // ルーティングで設定した通りHTTPメソッドをGETに指定
       type: 'GET',
-      //dataオプションでリクエストに値を含める
+      // dataオプションでリクエストに値を含める
       data: { id: last_message_id },
       dataType: 'json'
     })
@@ -74,6 +74,7 @@ $(function () {
       });
       // メッセージが入ったHTMLに入れ物ごと追加
       $('.MainChat__MessageList').append(insertHTML);
+      $('.MainChat__MessageList').animate({ scrollTop: $('.MainChat__MessageList')[0].scrollHeight }, 'fast');
     })
     .fail(function () {
       alert("error");

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -16,13 +16,11 @@ $(function () {
 
   function buildHTML(message) {
     if (message.image) {
-      // data-message-idが反映されるようにしている
       return `<div class="MessageInfo" data-message-id=${message.id}>
                 ${buildTopBox_and_Text(message)}
                 <img src=${message.image} class="MessageInfo--Img">
               </div>`;
     } else {
-      // 同様にdata-message-idが反映されるようにしている
       return `<div class="MessageInfo" data-message-id=${message.id}>
                 ${buildTopBox_and_Text(message)}
               </div>`;
@@ -54,26 +52,19 @@ $(function () {
   });
 
   var reloadMessages = function () {
-    // カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
     var last_message_id = $('.MessageInfo:last').data("message-id");
     $.ajax({
-      // ルーティングで設定した通りのURLを指定
       url: 'api/messages',
-      // ルーティングで設定した通りHTTPメソッドをGETに指定
       type: 'GET',
-      // dataオプションでリクエストに値を含める
       data: { id: last_message_id },
       dataType: 'json'
     })
     .done(function (messages) {
       if (messages.length !== 0) {
-        // 追加するHTMLの入れ物を作る
         var insertHTML = "";
-        // 配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物insertHTMLに足し合わせる
         messages.forEach(function (message) {
           insertHTML += buildHTML(message);
         });
-        // メッセージが入ったHTMLに入れ物ごと追加
         $('.MainChat__MessageList').append(insertHTML);
         $('.MainChat__MessageList').animate({ scrollTop: $('.MainChat__MessageList')[0].scrollHeight }, 'fast');
       };

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,5 +1,8 @@
 $(function () {
 
+  var last_message_id = $('.MessageInfo:last').data('message-id');
+  console.log(last_message_id);
+
   function buildTopBox_and_Text(message) {
     return `<div class="MessageInfo__TopBox">
               <p class="MessageInfo__TopBox--Name">

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -3,7 +3,7 @@ $(function () {
   function addUser(user) {
     var html = `<div class="chat-group-user clearfix">
                   <p class="chat-group-user__name">${user.name}</p>
-                  <a class="chat-group-user__btn chat-group-user__btn--add" data-user-id="${user.id}" data-user-name="${user.name}">追加</a>
+                  <a class="chat-group-user__btn chat-group-user__btn--add" data-user-id=${user.id} data-user-name=${user.name}>追加</a>
                 </div>`;
     $('#user-search-result').append(html);
   };
@@ -17,7 +17,7 @@ $(function () {
 
   function addChatMember(user_id, user_name) {
     var html = `<div class="chat-group-user clearfix">
-                  <input name="group[user_ids][]" type="hidden" value="${user_id}">
+                  <input name="group[user_ids][]" type="hidden" value=${user_id}>
                   <p class="chat-group-user__name">${user_name}</p>
                   <a class="chat-group-user__btn chat-group-user__btn--remove">削除</a>
                 </div>`;

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,3 @@
+class Api::MessagesController < ApplicationController
+
+end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,3 +1,5 @@
 class Api::MessagesController < ApplicationController
+  def index
 
+  end
 end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,5 +1,10 @@
 class Api::MessagesController < ApplicationController
   def index
-
+    # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
+    group = Group.find(params[:group_id])
+    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
+    last_message_id = params[:id].to_i
+    # 取得したグループでのメッセージ達から、idがlast_message_idよりも新しい(大きい)メッセージ達のみを取得
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
   end
 end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,10 +1,7 @@
 class Api::MessagesController < ApplicationController
   def index
-    # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
     group = Group.find(params[:group_id])
-    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
     last_message_id = params[:id].to_i
-    # 取得したグループでのメッセージ達から、idがlast_message_idよりも新しい(大きい)メッセージ達のみを取得
     @messages = group.messages.includes(:user).where('id > ?', last_message_id)
   end
 end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -5,6 +5,6 @@ class Api::MessagesController < ApplicationController
     # ajaxで送られてくる最後のメッセージのid番号を変数に代入
     last_message_id = params[:id].to_i
     # 取得したグループでのメッセージ達から、idがlast_message_idよりも新しい(大きい)メッセージ達のみを取得
-    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+    @messages = group.messages.includes(:user).where('id > ?', last_message_id)
   end
 end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.id    message.id
+  json.name  message.user.name
+  json.text  message.body
+  json.image message.image.url
+  json.date  message.created_at.strftime("%Y/%m/%d(%a) %T")
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.MessageInfo
+.MessageInfo{data: {message: {id: message.id}}}
   .MessageInfo__TopBox
     %p.MessageInfo__TopBox--Name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,5 @@
+json.id    @message.id
 json.name  @message.user.name
-json.date  @message.created_at.strftime("%Y/%m/%d(%a) %T")
 json.text  @message.body
 json.image @message.image.url
+json.date  @message.created_at.strftime("%Y/%m/%d(%a) %T")

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,3 @@
-# idもデータとして渡す
 json.id    @message.id
 json.name  @message.user.name
 json.text  @message.body

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,3 +1,4 @@
+# idもデータとして渡す
 json.id    @message.id
 json.name  @message.user.name
 json.text  @message.body

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,11 @@
 Rails.application.routes.draw do
   devise_for :users
-  root "groups#index"
+  root 'groups#index'
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
https://user-images.githubusercontent.com/66543070/106276528-0dfb3b00-627b-11eb-9378-d2c4296df2c0.mp4

https://user-images.githubusercontent.com/66543070/106276278-b65ccf80-627a-11eb-9c02-dfd067dae19e.mp4

https://user-images.githubusercontent.com/66543070/106276360-cd9bbd00-627a-11eb-856e-11a15d29093b.mp4

# What
本アプリの仕上げとして、チャットが自動で更新されるようにする。ブラウザに表示されている最新のメッセージのIDを数秒ごとにJavaScriptを用いてリクエストとして送り、Railsコントローラのアクションにてデータベースに保存されている最新のIDと比較する。ブラウザの最新メッセージのIDよりも大きいIDをもつメッセージの一群をレスポンスして、もう一度JavaScriptを用いてそれらをリストの最後に追加するようにする。

# Why
自分が投稿したメッセージは、プルリク#8 により非同期で画面に表示されるようになった。しかし、同じグループに所属している他のユーザーの投稿メッセージは、現段階ではリロードしなければ反映されない(逆もまた然り)。これではとてもじゃないが「チャット」とは言えないので、 *LINE* や *Slack* などのSNSツールのように自動でブラウザ上の画面が更新されるようにする必要がある。こうすることによって、毎回毎回リロード作業を行わなくても他のユーザーのメッセージも常に表示されるようになり、快適なチャットライフを送ることができる。

# How(工夫点)
- アニメーションの速度を *'fast'* にした。
- #9 に合わせて、 **forEachメソッド** を代わりに使用した。

# Dreams(改善点)
- サイドバーの所属グループリストにも、定期的に最新のメッセージが表示されるように自動更新させる。
- Sample版のChatSpaceもそうだけど、ログアウトやユーザーが削除されたときに、一度エラーのアラートが表示されたら２回目以降のアラートが表示されないように停止させる。
-  *LINE* のグループのように、新しいユーザーが加わったら『〇〇さんが参加しました』、 *Slack* のように、グループが新規作成されたら『〇〇さんが新しいグループ「〇〇」を作りました』などの文をフラッシュメッセージ形式で表示させるようにしたら、もっと素敵なアプリケーションになる！(確信)